### PR TITLE
增加on-focus返回值event。

### DIFF
--- a/src/views/components/input-number-en.vue
+++ b/src/views/components/input-number-en.vue
@@ -188,7 +188,7 @@
                         <tr>
                             <td>on-focus</td>
                             <td>Trigger on focus.</td>
-                            <td>-</td>
+                            <td>event</td>
                         </tr>
                         <tr>
                             <td>on-blur</td>

--- a/src/views/components/input-number.vue
+++ b/src/views/components/input-number.vue
@@ -188,7 +188,7 @@
                         <tr>
                             <td>on-focus</td>
                             <td>聚焦时触发</td>
-                            <td>-</td>
+                            <td>event</td>
                         </tr>
                         <tr>
                             <td>on-blur</td>


### PR DESCRIPTION
为实现inputnumber获取焦点时自动选中已有值，增加on-focus返回值event。
可用event.target.select()选中值。
对应修改文档。