### PR TITLE
fix 锚点拼音字符重复的问题

### DIFF
--- a/src/components/demo.vue
+++ b/src/components/demo.vue
@@ -102,7 +102,16 @@
                 return style;
             },
             title_link () {
-                const title = pinyinUtil.getFirstLetter(this.title);
+                // Generate four random hex digits. 
+                function S4 () {
+                    return (((1+Math.random())*0x10000)|0).toString(16).substring(1);
+                };
+                // Generate a GUID like string by concatenating random hexadecimal. 
+                function guid () {
+                    return `${S4()}${S4()}_${S4()}_${S4()}_${S4()}_${S4()}${S4()}${S4()}`;
+                };
+
+                const title = `${pinyinUtil.getFirstLetter(this.title)}_${guid()}`;
                 return title.replace(/\s/g, '_');
             }
         },


### PR DESCRIPTION
问题：
https://www.iviewui.com/components/table  页面的报错：
![default](https://user-images.githubusercontent.com/7201507/48481459-8e732400-e848-11e8-92bb-04f4fa8fecc8.PNG)

修复方案：
通过在生成的拼音缩写后添加类似Guid的字符串来解决这个问题，改动较小。
